### PR TITLE
Fix race condition for concurrent NewScope calls

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -24,8 +24,7 @@ var tensorCounter uint64
 
 // NewScope returns a unique scope in the format
 // input_<suffix> where suffix is a counter
-// This function is not thread safe and shouldn't be called
-// in parallel
+// This function isthread safe can be called in parallel
 func NewScope(root *op.Scope) *op.Scope {
 	var scope = atomic.AddUint64(&tensorCounter, 1)
 	return root.SubScope(fmt.Sprint("input_", scope))

--- a/scope.go
+++ b/scope.go
@@ -15,16 +15,18 @@ package tfgo
 
 import (
 	"fmt"
+	"sync/atomic"
+
 	"github.com/tensorflow/tensorflow/tensorflow/go/op"
 )
 
-var tensorCounter int
+var tensorCounter uint64
 
 // NewScope returns a unique scope in the format
 // input_<suffix> where suffix is a counter
 // This function is not thread safe and shouldn't be called
 // in parallel
 func NewScope(root *op.Scope) *op.Scope {
-	tensorCounter++
-	return root.SubScope(fmt.Sprint("input_", tensorCounter))
+	var scope = atomic.AddUint64(&tensorCounter, 1)
+	return root.SubScope(fmt.Sprint("input_", scope))
 }

--- a/scope.go
+++ b/scope.go
@@ -24,7 +24,7 @@ var tensorCounter uint64
 
 // NewScope returns a unique scope in the format
 // input_<suffix> where suffix is a counter
-// This function isthread safe can be called in parallel
+// This function isthread safe can be called in parallel for DIFFERENT scopes.
 func NewScope(root *op.Scope) *op.Scope {
 	var scope = atomic.AddUint64(&tensorCounter, 1)
 	return root.SubScope(fmt.Sprint("input_", scope))


### PR DESCRIPTION
Thanks for awesome project!

Since golang uses a multithreading concurrency model, please consider using atomic operations for global counters.
Explanation: https://gobyexample.com/atomic-counters